### PR TITLE
chore: upgrade pnpm to 11.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
       "optional": true
     }
   },
-  "packageManager": "pnpm@10.33.4",
+  "packageManager": "pnpm@11.1.2",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,7 @@
 packages:
   - 'playground'
+
+allowBuilds:
+  '@swc/core': false
+  core-js: false
+  simple-git-hooks: false

--- a/src/runtime/asyncChunkRetry.ts
+++ b/src/runtime/asyncChunkRetry.ts
@@ -194,10 +194,7 @@ function ensureChunk(chunkId: string): Promise<unknown> {
   }
   const callingCounter: { count: number; cssFailedCount: number } = args[10];
 
-  const result = originalEnsureChunk.apply(
-    null,
-    args as Parameters<EnsureChunk>,
-  );
+  const result = originalEnsureChunk(...(args as Parameters<EnsureChunk>));
 
   try {
     const originalScriptFilename = originalGetChunkScriptFilename(chunkId);
@@ -325,7 +322,7 @@ function loadScript(): string {
   if (retry) {
     args[0] = retry.nextRetryUrl;
   }
-  return originalLoadScript.apply(null, args);
+  return originalLoadScript(...args);
 }
 
 function loadStyleSheet(href: string, chunkId: ChunkId): string {

--- a/src/runtime/asyncChunkRetry.ts
+++ b/src/runtime/asyncChunkRetry.ts
@@ -194,7 +194,10 @@ function ensureChunk(chunkId: string): Promise<unknown> {
   }
   const callingCounter: { count: number; cssFailedCount: number } = args[10];
 
-  const result = originalEnsureChunk(...(args as Parameters<EnsureChunk>));
+  const result = originalEnsureChunk.apply(
+    null,
+    args as Parameters<EnsureChunk>,
+  );
 
   try {
     const originalScriptFilename = originalGetChunkScriptFilename(chunkId);
@@ -322,7 +325,7 @@ function loadScript(): string {
   if (retry) {
     args[0] = retry.nextRetryUrl;
   }
-  return originalLoadScript(...args);
+  return originalLoadScript.apply(null, args);
 }
 
 function loadStyleSheet(href: string, chunkId: ChunkId): string {


### PR DESCRIPTION
## Summary

This PR upgrades the repository package manager metadata to pnpm 11.1.2 and updates pnpm 11 install configuration where dependency build scripts need an explicit allowBuilds decision. Lockfile or small validation fixes are included only where pnpm 11/local checks required them.

## Related Links

- https://github.com/pnpm/pnpm/releases/tag/v11.1.2
- https://github.com/pnpm/pnpm/releases/tag/v11.0.0
