### PR TITLE
chore(infra): enable tsgo, publint

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,10 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
+        node-version: [20.19.0, 24.16.0]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -26,7 +28,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: 24.16.0
+          node-version: ${{ matrix.node-version }}
           package-manager-cache: false
 
       - name: Install Pnpm

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,10 +15,8 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node-version: [20.19.0, 24.16.0]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -28,7 +26,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 24.16.0
           package-manager-cache: false
 
       - name: Install Pnpm

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# Repository Guidelines
+
+## Project Structure
+
+- `src/` contains the plugin source and browser runtime code.
+- `test/` contains Playwright integration tests and fixtures.
+- `playground/` is the local Rsbuild app used for manual verification.
+- `dist/` and `.rslib/` are generated build artifacts.
+
+## Tooling
+
+- Build with Rslib: `pnpm build`.
+- Lint with Rslint and Prettier: `pnpm lint`; apply fixes with `pnpm lint:write`.
+- Run tests with Playwright: `pnpm test`.
+- Use Node.js `^20.19.0 || >=22.12.0` and pnpm 11.
+
+## Package Contract
+
+- The package is ESM-only and exposes `./dist/index.js` through `package.json#exports`.
+- Runtime retry scripts are built as browser IIFE artifacts under `dist/runtime/`.
+- Keep public types aligned with the exported entry point.
+- Do not edit generated `dist/` or `.rslib/` output by hand.
+
+## Validation
+
+Before opening a PR, run:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm lint
+pnpm build
+pnpm test
+npm pack --dry-run
+```

--- a/package.json
+++ b/package.json
@@ -59,6 +59,9 @@
       "optional": true
     }
   },
+  "engines": {
+    "node": "^20.19.0 || >=22.12.0"
+  },
   "packageManager": "pnpm@11.7.0",
   "publishConfig": {
     "access": "public",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@types/serialize-javascript": "^5.0.4",
+    "@typescript/native-preview": "7.0.0-dev.20260527.2",
     "playwright": "^1.61.0",
     "prettier": "^3.8.4",
     "react": "^19.2.7",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
   "name": "@rsbuild/plugin-assets-retry",
   "version": "2.0.1",
   "description": "An Rsbuild plugin to automatically resend requests when static assets fail to load.",
-  "repository": "https://github.com/rstackjs/rsbuild-plugin-assets-retry",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rstackjs/rsbuild-plugin-assets-retry.git"
+  },
   "homepage": "https://github.com/rstackjs/rsbuild-plugin-assets-retry#readme",
   "bugs": {
     "url": "https://github.com/rstackjs/rsbuild-plugin-assets-retry/issues"
@@ -48,6 +51,7 @@
     "prettier": "^3.8.4",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
+    "rsbuild-plugin-publint": "^1.0.0",
     "serialize-javascript": "^7.0.5",
     "simple-git-hooks": "^2.13.1",
     "typescript": "6.0.3"

--- a/package.json
+++ b/package.json
@@ -64,9 +64,6 @@
       "optional": true
     }
   },
-  "engines": {
-    "node": "^20.19.0 || >=22.12.0"
-  },
   "packageManager": "pnpm@11.7.0",
   "publishConfig": {
     "access": "public",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       react-dom:
         specifier: ^19.2.7
         version: 19.2.7(react@19.2.7)
+      rsbuild-plugin-publint:
+        specifier: ^1.0.0
+        version: 1.0.0(@rsbuild/core@2.0.15)
       serialize-javascript:
         specifier: ^7.0.5
         version: 7.0.5
@@ -164,6 +167,10 @@ packages:
     resolution: {integrity: sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@publint/pack@0.1.4':
+    resolution: {integrity: sha512-HDVTWq3H0uTXiU0eeSQntcVUTPP3GamzeXI41+x7uU9J65JgWQh3qWZHblR1i0npXfFtF+mxBiU2nJH8znxWnQ==}
+    engines: {node: '>=18'}
 
   '@rsbuild/core@2.0.15':
     resolution: {integrity: sha512-O8vmMhZu1YImO6jOqt/K/vlJSvkq7UtSq5YM1DIlcEd9LW8Gf6/dkQ1B2KPI6F+hSMFBnTTTumdcIowSLCw97g==}
@@ -606,8 +613,18 @@ packages:
     resolution: {integrity: sha512-Rwi3pnapEqirPSbWbrZaa6N3nmqq4Xer/2XooiOKyV3q12ML06f7MOuc5DVH8ONZIFhwIYQ3yzPH4nt7iWHaTg==}
     engines: {node: 18 || 20 || >=22}
 
+  mri@1.2.0:
+    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
+    engines: {node: '>=4'}
+
+  package-manager-detector@1.6.0:
+    resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
+
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
@@ -626,6 +643,11 @@ packages:
   prettier@3.8.4:
     resolution: {integrity: sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==}
     engines: {node: '>=14'}
+    hasBin: true
+
+  publint@0.3.21:
+    resolution: {integrity: sha512-OqejcnMV6E9zel2oCrUOJEiiFkGiAAni0A6ibfQNh1k9Gu5z4F+Yso8lllam7AzmV6Do0vp7u3UpZNRBwuXaHQ==}
+    engines: {node: '>=18'}
     hasBin: true
 
   react-dom@19.2.7:
@@ -665,6 +687,19 @@ packages:
         optional: true
       typescript:
         optional: true
+
+  rsbuild-plugin-publint@1.0.0:
+    resolution: {integrity: sha512-QNu6zL0TOmFZfrCiKSmkw092jDhhPpiA1QYDRkvhkW1wDLowuVEYOqdV87Eo/I6geV0nuKKnCgLHT+Fevbz6pA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@rsbuild/core': ^1.0.0 || ^2.0.0-0
+    peerDependenciesMeta:
+      '@rsbuild/core':
+        optional: true
+
+  sade@1.8.1:
+    resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
+    engines: {node: '>=6'}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -823,6 +858,8 @@ snapshots:
   '@playwright/test@1.61.0':
     dependencies:
       playwright: 1.61.0
+
+  '@publint/pack@0.1.4': {}
 
   '@rsbuild/core@2.0.15':
     dependencies:
@@ -1176,7 +1213,13 @@ snapshots:
     dependencies:
       brace-expansion: 5.0.4
 
+  mri@1.2.0: {}
+
+  package-manager-detector@1.6.0: {}
+
   path-parse@1.0.7: {}
+
+  picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
 
@@ -1189,6 +1232,13 @@ snapshots:
       fsevents: 2.3.2
 
   prettier@3.8.4: {}
+
+  publint@0.3.21:
+    dependencies:
+      '@publint/pack': 0.1.4
+      package-manager-detector: 1.6.0
+      picocolors: 1.1.1
+      sade: 1.8.1
 
   react-dom@19.2.7(react@19.2.7):
     dependencies:
@@ -1215,6 +1265,16 @@ snapshots:
       '@microsoft/api-extractor': 7.58.9(@types/node@24.13.2)
       '@typescript/native-preview': 7.0.0-dev.20260527.2
       typescript: 6.0.3
+
+  rsbuild-plugin-publint@1.0.0(@rsbuild/core@2.0.15):
+    dependencies:
+      publint: 0.3.21
+    optionalDependencies:
+      '@rsbuild/core': 2.0.15
+
+  sade@1.8.1:
+    dependencies:
+      mri: 1.2.0
 
   scheduler@0.27.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ importers:
         version: 2.0.1(@rsbuild/core@2.0.15)(@rspack/core@2.0.8(@swc/helpers@0.5.23))
       '@rslib/core':
         specifier: ^0.23.0
-        version: 0.23.0(@microsoft/api-extractor@7.58.9(@types/node@24.13.2))(typescript@6.0.3)
+        version: 0.23.0(@microsoft/api-extractor@7.58.9(@types/node@24.13.2))(@typescript/native-preview@7.0.0-dev.20260527.2)(typescript@6.0.3)
       '@rslint/core':
         specifier: ^0.6.2
         version: 0.6.2
@@ -41,6 +41,9 @@ importers:
       '@types/serialize-javascript':
         specifier: ^5.0.4
         version: 5.0.4
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260527.2
+        version: 7.0.0-dev.20260527.2
       playwright:
         specifier: ^1.61.0
         version: 1.61.0
@@ -469,6 +472,53 @@ packages:
   '@types/serialize-javascript@5.0.4':
     resolution: {integrity: sha512-Z2R7UKFuNWCP8eoa2o9e5rkD3hmWxx/1L0CYz0k2BZzGh0PhEVMp9kfGiqEml/0IglwNERXZ2hwNzIrSz/KHTA==}
 
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260527.2':
+    resolution: {integrity: sha512-3LqSu4DlxkEfeC/Z/29QMCJn5jjkDtXI7LYuxfmjdmAatS6umDKqm8J17fnP/7fyrZUMBTIYRwSDpChGV3G1ew==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260527.2':
+    resolution: {integrity: sha512-H4+sxE9qaBbLF83wMdWE0FsgfK0Pom+/O+/oxqyGzhVkDJlNt3vfpgQZMit48/Gm44AacGfBggJ9Dhbi3aeSFw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260527.2':
+    resolution: {integrity: sha512-BGUDMjC2Z3TTdZRkGGwhBLelkP5UYgO2rbep8aF4dS3fu7T5lFPPrnfS6EgqJgie+cF5Fsev7xEq8wWyBDM+lg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260527.2':
+    resolution: {integrity: sha512-6I9Cv9ozwfS9zB9vRQDPIYseLX3artEO9jl3yVgLj4ishwlSF4cWAbIsjl5IztPaEgHv8coej/6tX1D0uaBzXg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260527.2':
+    resolution: {integrity: sha512-vpazOu+ozlxBo8U57YJMzsOPuxAV8H7fu36KJ8ea8At/D8pdGmOAy5TuB+9OBQV9JDe0OXJMy2kmbhOpmkTAmA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260527.2':
+    resolution: {integrity: sha512-DBFnFE3V6AITkPO1K1VxXf3yEZKjU2FwtXlNwRqhzDu0rrL2SsJHOSrBDX+OacTxQFzZMxFcpiuhV8jHZALPEg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260527.2':
+    resolution: {integrity: sha512-1tBlErMvQgcMqqYwsx4tytupcjCJcOUXD3vBn1Wb/kAvus1FzWQAFE0fcKBvLfcqLQfTiiEwKKEtbLjGmakqqg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@typescript/native-preview@7.0.0-dev.20260527.2':
+    resolution: {integrity: sha512-piqkDwikVeizCFqA1lcwI5F4wOAtBdxuliWe77ApBNRyBPPvfCJB+u/HYi9/8t5nd0sWvFs6/qt/AzJ1CCoykQ==}
+    engines: {node: '>=16.20.0'}
+    hasBin: true
+
   ajv-draft-04@1.0.0:
     resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
     peerDependencies:
@@ -790,10 +840,10 @@ snapshots:
     transitivePeerDependencies:
       - '@rspack/core'
 
-  '@rslib/core@0.23.0(@microsoft/api-extractor@7.58.9(@types/node@24.13.2))(typescript@6.0.3)':
+  '@rslib/core@0.23.0(@microsoft/api-extractor@7.58.9(@types/node@24.13.2))(@typescript/native-preview@7.0.0-dev.20260527.2)(typescript@6.0.3)':
     dependencies:
       '@rsbuild/core': 2.0.15
-      rsbuild-plugin-dts: 0.23.0(@microsoft/api-extractor@7.58.9(@types/node@24.13.2))(@rsbuild/core@2.0.15)(typescript@6.0.3)
+      rsbuild-plugin-dts: 0.23.0(@microsoft/api-extractor@7.58.9(@types/node@24.13.2))(@rsbuild/core@2.0.15)(@typescript/native-preview@7.0.0-dev.20260527.2)(typescript@6.0.3)
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.9(@types/node@24.13.2)
       typescript: 6.0.3
@@ -1023,6 +1073,37 @@ snapshots:
 
   '@types/serialize-javascript@5.0.4': {}
 
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260527.2':
+    optional: true
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260527.2':
+    optional: true
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260527.2':
+    optional: true
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260527.2':
+    optional: true
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260527.2':
+    optional: true
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260527.2':
+    optional: true
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260527.2':
+    optional: true
+
+  '@typescript/native-preview@7.0.0-dev.20260527.2':
+    optionalDependencies:
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260527.2
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260527.2
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260527.2
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260527.2
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260527.2
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260527.2
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260527.2
+
   ajv-draft-04@1.0.0(ajv@8.18.0):
     optionalDependencies:
       ajv: 8.18.0
@@ -1126,12 +1207,13 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
-  rsbuild-plugin-dts@0.23.0(@microsoft/api-extractor@7.58.9(@types/node@24.13.2))(@rsbuild/core@2.0.15)(typescript@6.0.3):
+  rsbuild-plugin-dts@0.23.0(@microsoft/api-extractor@7.58.9(@types/node@24.13.2))(@rsbuild/core@2.0.15)(@typescript/native-preview@7.0.0-dev.20260527.2)(typescript@6.0.3):
     dependencies:
       '@ast-grep/napi': 0.37.0
       '@rsbuild/core': 2.0.15
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.9(@types/node@24.13.2)
+      '@typescript/native-preview': 7.0.0-dev.20260527.2
       typescript: 6.0.3
 
   scheduler@0.27.0: {}

--- a/rslib.config.ts
+++ b/rslib.config.ts
@@ -66,6 +66,7 @@ export default defineConfig({
       syntax: 'es2023',
       dts: {
         bundle: true,
+        tsgo: true,
       },
       source: {
         entry: {

--- a/rslib.config.ts
+++ b/rslib.config.ts
@@ -3,6 +3,7 @@ import { performance } from 'node:perf_hooks';
 import { type RsbuildPlugin, logger } from '@rsbuild/core';
 import { defineConfig } from '@rslib/core';
 import { minify } from '@swc/core';
+import { pluginPublint } from 'rsbuild-plugin-publint';
 import pkgJson from './package.json';
 
 /**
@@ -61,6 +62,7 @@ const pluginGenerateMinified: (filename: string) => RsbuildPlugin = (
 });
 
 export default defineConfig({
+  plugins: [pluginPublint()],
   lib: [
     {
       syntax: 'es2023',

--- a/rslint.config.ts
+++ b/rslint.config.ts
@@ -1,9 +1,10 @@
-import { defineConfig, ts } from '@rslint/core';
+import { defineConfig, js, ts } from '@rslint/core';
 
 export default defineConfig([
   {
     ignores: ['src/runtime/runtime.d.ts'],
   },
+  js.configs.recommended,
   ts.configs.recommended,
   {
     rules: {


### PR DESCRIPTION
## Summary

This PR tightens the remaining repository infrastructure baseline on top of the latest `origin/main`: it documents agent-facing repo conventions, expands CI coverage to Node 20 and 24, enables Rslib declaration generation through tsgo, adds publint package validation through Rslib, and makes Rslint run both JS and TS recommended rules.

## Validation

- `CI=true corepack pnpm install --frozen-lockfile=false`
- `corepack pnpm peers check`
- `corepack pnpm run lint`
- `corepack pnpm run build`
- `corepack pnpm run test`
- `npm pack --dry-run`
