### PR TITLE
docs: add package support metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "2.0.1",
   "description": "An Rsbuild plugin to automatically resend requests when static assets fail to load.",
   "repository": "https://github.com/rstackjs/rsbuild-plugin-assets-retry",
+  "homepage": "https://github.com/rstackjs/rsbuild-plugin-assets-retry#readme",
+  "bugs": {
+    "url": "https://github.com/rstackjs/rsbuild-plugin-assets-retry/issues"
+  },
   "license": "MIT",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary
- add the package homepage pointing to the repository README
- add the package bugs URL pointing to GitHub issues

## Validation
- `node -e "const p=require('./package.json'); if (p.homepage !== 'https://github.com/rstackjs/rsbuild-plugin-assets-retry#readme') throw new Error('homepage mismatch'); if (!p.bugs || p.bugs.url !== 'https://github.com/rstackjs/rsbuild-plugin-assets-retry/issues') throw new Error('bugs url mismatch'); console.log(JSON.stringify({name:p.name, homepage:p.homepage, bugs:p.bugs.url}, null, 2));"`
- `npm view @rsbuild/plugin-assets-retry@latest name version repository.url homepage bugs --json`
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm run lint`
- `pnpm run build`
- `pnpm exec playwright test --grep-invert "domain, onRetry and onFail options should work when retrying async chunk failed"` (30 passed)
- `npm pack --dry-run --ignore-scripts --json .`
- `git diff --check`

Note: `pnpm run test` currently reports one failure in `test/basic/onRetryAsync.test.ts:81` in this local environment. I reproduced the same single-test failure on `origin/main` (`98807f4`) after building, so it appears pre-existing and unrelated to this metadata-only change.