### PR TITLE
fix(runtime): compile retry scripts to es5

### DIFF
--- a/rslib.config.ts
+++ b/rslib.config.ts
@@ -21,7 +21,7 @@ const pluginGenerateMinified: (filename: string) => RsbuildPlugin = (
     async function minifyRuntimeFile(distCode: string) {
       const startTime = performance.now();
       const { code: minifiedRuntimeCode } = await minify(distCode, {
-        ecma: 6,
+        ecma: 5,
         // allows SWC to mangle function names
         module: true,
         compress: {
@@ -78,7 +78,7 @@ export default defineConfig({
     },
     {
       format: 'iife',
-      syntax: 'es6',
+      syntax: 'es5',
       source: {
         entry: {
           'runtime/initialChunkRetry': 'src/runtime/initialChunkRetry.ts',
@@ -91,7 +91,7 @@ export default defineConfig({
     },
     {
       format: 'iife',
-      syntax: 'es6',
+      syntax: 'es5',
       source: {
         entry: {
           'runtime/asyncChunkRetry': 'src/runtime/asyncChunkRetry.ts',

--- a/test/basic/dataAttribute.test.ts
+++ b/test/basic/dataAttribute.test.ts
@@ -1,7 +1,27 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { expect, test } from '@playwright/test';
 import { createRsbuild } from '@rsbuild/core';
 import { ASSETS_RETRY_DATA_ATTRIBUTE, pluginAssetsRetry } from '../../dist';
 import { getRandomPort } from './helper';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const runtimeDir = path.resolve(__dirname, '../../dist/runtime');
+const es6PlusSyntaxRE = /\b(?:const|let|class)\b|=>|\?\?|\?\.|\.\.\.|`/;
+const runtimeFiles = [
+  'initialChunkRetry.js',
+  'initialChunkRetry.min.js',
+  'asyncChunkRetry.js',
+  'asyncChunkRetry.min.js',
+];
+
+test('should emit retry runtime without ES6+ syntax', () => {
+  for (const filename of runtimeFiles) {
+    const code = fs.readFileSync(path.join(runtimeDir, filename), 'utf-8');
+    expect(code).not.toMatch(es6PlusSyntaxRE);
+  }
+});
 
 test('should add data attribute to inline retry script', async ({ page }) => {
   const rsbuild = await createRsbuild({


### PR DESCRIPTION
## Summary

- compile the retry runtime IIFE bundles to ES5 again
- minify retry runtime code with SWC `ecma: 5`
- add a regression test that checks emitted retry runtime files do not contain common ES6+ syntax

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm build`
- `rg -n '\b(const|let|class)\b|=>|\?\?|\?\.|\.\.\.|`' dist/runtime` (no matches)
- `pnpm exec playwright test test/basic/dataAttribute.test.ts`
- `pnpm lint`
- `pnpm test`
- `npm pack --dry-run`

Fixes #86

https://github.com/rstackjs/rsbuild-plugin-assets-retry/pull/68
