### PR TITLE
chore: reuse shared test utilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@rsbuild/plugin-react": "^2.1.0",
     "@rslib/core": "^0.23.2",
     "@rslint/core": "^0.6.4",
+    "@rstackjs/test-utils": "^0.2.0",
     "@rstest/core": "^0.11.1",
     "@rstest/playwright": "^0.11.1",
     "@swc/core": "^1.15.43",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@rslint/core':
         specifier: ^0.6.4
         version: 0.6.4
+      '@rstackjs/test-utils':
+        specifier: ^0.2.0
+        version: 0.2.0
       '@rstest/core':
         specifier: ^0.11.1
         version: 0.11.1
@@ -429,6 +432,9 @@ packages:
     peerDependenciesMeta:
       '@rspack/core':
         optional: true
+
+  '@rstackjs/test-utils@0.2.0':
+    resolution: {integrity: sha512-P+LOo1WE3xYeGkHmEthyq2cIpN69k4LhiB/4UBSceD+nW9hDlhWv8MC0LTLWokZXccWl4ntcfOBjQFllkcBlPA==}
 
   '@rstest/core@0.11.1':
     resolution: {integrity: sha512-9iJnDrM/zYuHyk1//CMr/Jer2XughgN3fYagGb1YWpMLUke+E+WXlUPgACwf7OkmIB47/TttbLFK+4zwGDNOFg==}
@@ -1256,6 +1262,8 @@ snapshots:
       react-refresh: 0.18.0
     optionalDependencies:
       '@rspack/core': 2.1.3(@swc/helpers@0.5.23)
+
+  '@rstackjs/test-utils@0.2.0': {}
 
   '@rstest/core@0.11.1':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,3 +10,4 @@ minimumReleaseAgeExclude:
   - typescript
   - '@typescript/*'
   - '@rstest/*'
+  - '@rstackjs/test-utils@0.2.0'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,4 +10,4 @@ minimumReleaseAgeExclude:
   - typescript
   - '@typescript/*'
   - '@rstest/*'
-  - '@rstackjs/test-utils@0.2.0'
+  - '@rstackjs/*'

--- a/test/basic/dataAttribute.test.ts
+++ b/test/basic/dataAttribute.test.ts
@@ -13,7 +13,7 @@ test('should add data attribute to inline retry script', async ({ page }) => {
         }),
       ],
       server: {
-        port: getRandomPort(),
+        port: await getRandomPort(),
       },
     },
   });
@@ -45,7 +45,7 @@ test('should add data attribute to external retry script', async ({ page }) => {
         }),
       ],
       server: {
-        port: getRandomPort(),
+        port: await getRandomPort(),
       },
     },
   });
@@ -79,7 +79,7 @@ test('should be able to filter retry script in HTML template', async ({
         }),
       ],
       server: {
-        port: getRandomPort(),
+        port: await getRandomPort(),
       },
     },
   });

--- a/test/basic/helper.ts
+++ b/test/basic/helper.ts
@@ -1,23 +1,11 @@
 import { stripVTControlCharacters as stripAnsi } from 'node:util';
 import { type RequestHandler, createRsbuild } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
+import { getRandomPort, proxyConsole } from '@rstackjs/test-utils';
 import type { Page } from 'playwright';
 import { type PluginAssetsRetryOptions, pluginAssetsRetry } from '../../dist';
 
-const portMap = new Map();
-
-export function getRandomPort(
-  defaultPort = Math.ceil(Math.random() * 30000) + 15000,
-) {
-  let port = defaultPort;
-  while (true) {
-    if (!portMap.get(port)) {
-      portMap.set(port, 1);
-      return port;
-    }
-    port++;
-  }
-}
+export { getRandomPort, proxyConsole };
 
 export const getHrefByEntryName = (entryName: string, port: number) => {
   const htmlRoot = new URL(`http://localhost:${port}`);
@@ -140,7 +128,7 @@ export async function createRsbuildWithMiddleware(
           : {}),
       },
       server: {
-        port: port || getRandomPort(),
+        port: port || (await getRandomPort()),
         setup: ({ action, server }) => {
           if (action !== 'dev') {
             return;
@@ -216,32 +204,3 @@ export async function proxyPageConsole(page: Page, port: number) {
     onFailContextList,
   };
 }
-
-export const proxyConsole = (
-  types: string | string[] = ['log', 'warn', 'info', 'error'],
-  keepAnsi = false,
-) => {
-  const logs: string[] = [];
-  const restores: Array<() => void> = [];
-
-  for (const type of Array.isArray(types) ? types : [types]) {
-    const method = console[type];
-
-    restores.push(() => {
-      console[type] = method;
-    });
-
-    console[type] = (log) => {
-      logs.push(keepAnsi ? log : stripAnsi(log));
-    };
-  }
-
-  return {
-    logs,
-    restore: () => {
-      for (const restore of restores) {
-        restore();
-      }
-    },
-  };
-};

--- a/test/empty-src/index.test.ts
+++ b/test/empty-src/index.test.ts
@@ -12,7 +12,7 @@ const createDevServer = async () => {
         template: './index.html',
       },
       server: {
-        port: getRandomPort(),
+        port: await getRandomPort(),
       },
     },
   });


### PR DESCRIPTION
This PR replaces duplicated port allocation and console capture helpers with `@rstackjs/test-utils`. Port call sites now await the shared availability-aware implementation.