### PR TITLE
docs: refine retry domain examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,18 +168,21 @@ defineConfig({
 });
 ```
 
-You can also inject a custom variable into `window` and use it in the function:
+The host application can also inject custom variables such as `window.myAssetPath` and `window.userRegion` at runtime. The function can then use custom logic to select different backup domains by region:
 
 ```js
 // rsbuild.config.ts
 defineConfig({
   plugins: [
     pluginAssetsRetry({
-      domain: () => [
-        window.myAssetPath,
-        'https://cdn2.com/foo-path',
-        'https://cdn3.com',
-      ],
+      domain: () => {
+        const backupDomains =
+          window.userRegion === 'cn'
+            ? ['https://cdn2.cn/foo-path', 'https://cdn3.cn']
+            : ['https://cdn2.com/foo-path', 'https://cdn3.com'];
+
+        return [window.myAssetPath, ...backupDomains];
+      },
     }),
   ],
 });

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ defineConfig({
 
 #### Resolving the domain at runtime
 
-When the domain list is only known in the browser (for example it is injected on `window` at application startup), pass a function instead of a static array. Like the `onRetry` / `onFail` callbacks, the function is serialized into the runtime script and evaluated in the browser when the retry script starts, so it can read values that do not exist at build time. For example, the application can inject `window.myAssetPath`, and the function can use custom fallback logic:
+When the domain list is only known in the browser (for example it is injected on `window` at application startup), pass a function instead of a static array. Like the `onRetry` / `onFail` callbacks, the function is serialized into the runtime script and evaluated in the browser when the retry script starts, so it can read values that do not exist at build time:
 
 ```js
 // rsbuild.config.ts
@@ -160,8 +160,24 @@ defineConfig({
       domain: () => [
         // It can be http://localhost:3000 or https://cdn1.com.
         window.location.origin,
-        // Use an injected variable with a fallback value.
-        window.myAssetPath || 'https://cdn2.com/foo-path',
+        'https://cdn2.com/foo-path',
+        'https://cdn3.com',
+      ],
+    }),
+  ],
+});
+```
+
+You can also inject a custom variable into `window` and use it in the function:
+
+```js
+// rsbuild.config.ts
+defineConfig({
+  plugins: [
+    pluginAssetsRetry({
+      domain: () => [
+        window.myAssetPath,
+        'https://cdn2.com/foo-path',
         'https://cdn3.com',
       ],
     }),

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ defineConfig({
 
 #### Resolving the domain at runtime
 
-When the domain list is only known in the browser (for example it is injected on `window` at application startup), pass a function instead of a static array. Like the `onRetry` / `onFail` callbacks, the function is serialized into the runtime script and evaluated in the browser when the retry script starts, so it can read values that do not exist at build time:
+When the domain list is only known in the browser (for example it is injected on `window` at application startup), pass a function instead of a static array. Like the `onRetry` / `onFail` callbacks, the function is serialized into the runtime script and evaluated in the browser when the retry script starts, so it can read values that do not exist at build time. For example, the application can inject `window.myAssetPath`, and the function can use custom fallback logic:
 
 ```js
 // rsbuild.config.ts
@@ -160,7 +160,8 @@ defineConfig({
       domain: () => [
         // It can be http://localhost:3000 or https://cdn1.com.
         window.location.origin,
-        'https://cdn2.com/foo-path',
+        // Use an injected variable with a fallback value.
+        window.myAssetPath || 'https://cdn2.com/foo-path',
         'https://cdn3.com',
       ],
     }),

--- a/README.md
+++ b/README.md
@@ -129,11 +129,9 @@ If the assets request for `cdn2.com` also fails, the request will fallback to `c
 
 `domain` generates retry URLs using string replacement, so it supports full URLs starting with `https://` and CDN URLs with a path prefix, such as `https://cdn2.com/foo-path`. When using full URLs, every item in the array must include the protocol. In addition, `output.assetPrefix` cannot use a protocol-relative URL such as `//cdn1.com`, because it cannot be matched by the string replacement.
 
-```ts
-import { defineConfig } from '@rsbuild/core';
-import { pluginAssetsRetry } from '@rsbuild/plugin-assets-retry';
-
-export default defineConfig({
+```js
+// rsbuild.config.ts
+defineConfig({
   plugins: [
     pluginAssetsRetry({
       domain: [

--- a/README.md
+++ b/README.md
@@ -130,9 +130,10 @@ If the assets request for `cdn2.com` also fails, the request will fallback to `c
 `domain` generates retry URLs using string replacement, so it supports full URLs starting with `https://` and CDN URLs with a path prefix, such as `https://cdn2.com/foo-path`. When using full URLs, every item in the array must include the protocol. In addition, `output.assetPrefix` cannot use a protocol-relative URL such as `//cdn1.com`, because it cannot be matched by the string replacement.
 
 ```ts
+import { defineConfig } from '@rsbuild/core';
 import { pluginAssetsRetry } from '@rsbuild/plugin-assets-retry';
 
-export default {
+export default defineConfig({
   plugins: [
     pluginAssetsRetry({
       domain: [
@@ -145,7 +146,7 @@ export default {
   output: {
     assetPrefix: 'https://cdn1.com',
   },
-};
+});
 ```
 
 #### Resolving the domain at runtime

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ defineConfig({
 });
 ```
 
-The host application can also inject custom variables such as `window.myAssetPath` and `window.userRegion` at runtime. The function can then use custom logic to select different backup domains by region:
+It can also work with variables injected into `window`:
 
 ```js
 // rsbuild.config.ts

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -166,7 +166,7 @@ defineConfig({
 });
 ```
 
-宿主应用也可以在运行时注入 `window.myAssetPath`、`window.userRegion` 等自定义变量，再在函数中根据用户区域选择不同的备用域名：
+配合 `window` 注入的变量完成功能：
 
 ```js
 // rsbuild.config.ts

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -127,11 +127,9 @@ defineConfig({
 
 `domain` 使用字符串替换生成重试 URL，因此支持带 `https://` 开头的完整地址，也支持 CDN 地址包含子路径前缀，例如 `https://cdn2.com/foo-path`。使用完整地址时，数组中的每一项都必须带协议。此外，`output.assetPrefix` 不能使用 `//cdn1.com` 这样的协议相对地址，否则无法通过字符串替换匹配。
 
-```ts
-import { defineConfig } from '@rsbuild/core';
-import { pluginAssetsRetry } from '@rsbuild/plugin-assets-retry';
-
-export default defineConfig({
+```js
+// rsbuild.config.ts
+defineConfig({
   plugins: [
     pluginAssetsRetry({
       domain: [

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -147,7 +147,7 @@ defineConfig({
 
 #### 在运行时解析域名
 
-当域名列表只有在浏览器中才能确定时（例如在应用启动时注入到 `window` 上），可以传入一个函数来代替静态数组。与 `onRetry` / `onFail` 回调一样，该函数会被序列化到运行时脚本中，并在重试脚本启动时于浏览器中执行，因此可以读取构建时并不存在的值：
+当域名列表只有在浏览器中才能确定时（例如在应用启动时注入到 `window` 上），可以传入一个函数来代替静态数组。与 `onRetry` / `onFail` 回调一样，该函数会被序列化到运行时脚本中，并在重试脚本启动时于浏览器中执行，因此可以读取构建时并不存在的值。例如，应用可以注入 `window.myAssetPath`，并在函数中添加自定义的兜底逻辑：
 
 ```js
 // rsbuild.config.ts
@@ -158,7 +158,8 @@ defineConfig({
       domain: () => [
         // 可以是 http://localhost:3000，也可以是 https://cdn1.com。
         window.location.origin,
-        'https://cdn2.com/foo-path',
+        // 使用注入的变量，并提供兜底地址。
+        window.myAssetPath || 'https://cdn2.com/foo-path',
         'https://cdn3.com',
       ],
     }),

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -166,18 +166,21 @@ defineConfig({
 });
 ```
 
-也可以将自定义变量注入到 `window` 上，并在函数中使用：
+宿主应用也可以在运行时注入 `window.myAssetPath`、`window.userRegion` 等自定义变量，再在函数中根据用户区域选择不同的备用域名：
 
 ```js
 // rsbuild.config.ts
 defineConfig({
   plugins: [
     pluginAssetsRetry({
-      domain: () => [
-        window.myAssetPath,
-        'https://cdn2.com/foo-path',
-        'https://cdn3.com',
-      ],
+      domain: () => {
+        const backupDomains =
+          window.userRegion === 'cn'
+            ? ['https://cdn2.cn/foo-path', 'https://cdn3.cn']
+            : ['https://cdn2.com/foo-path', 'https://cdn3.com'];
+
+        return [window.myAssetPath, ...backupDomains];
+      },
     }),
   ],
 });

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -128,9 +128,10 @@ defineConfig({
 `domain` 使用字符串替换生成重试 URL，因此支持带 `https://` 开头的完整地址，也支持 CDN 地址包含子路径前缀，例如 `https://cdn2.com/foo-path`。使用完整地址时，数组中的每一项都必须带协议。此外，`output.assetPrefix` 不能使用 `//cdn1.com` 这样的协议相对地址，否则无法通过字符串替换匹配。
 
 ```ts
+import { defineConfig } from '@rsbuild/core';
 import { pluginAssetsRetry } from '@rsbuild/plugin-assets-retry';
 
-export default {
+export default defineConfig({
   plugins: [
     pluginAssetsRetry({
       domain: [
@@ -143,7 +144,7 @@ export default {
   output: {
     assetPrefix: 'https://cdn1.com',
   },
-};
+});
 ```
 
 #### 在运行时解析域名

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -147,7 +147,7 @@ defineConfig({
 
 #### 在运行时解析域名
 
-当域名列表只有在浏览器中才能确定时（例如在应用启动时注入到 `window` 上），可以传入一个函数来代替静态数组。与 `onRetry` / `onFail` 回调一样，该函数会被序列化到运行时脚本中，并在重试脚本启动时于浏览器中执行，因此可以读取构建时并不存在的值。例如，应用可以注入 `window.myAssetPath`，并在函数中添加自定义的兜底逻辑：
+当域名列表只有在浏览器中才能确定时（例如在应用启动时注入到 `window` 上），可以传入一个函数来代替静态数组。与 `onRetry` / `onFail` 回调一样，该函数会被序列化到运行时脚本中，并在重试脚本启动时于浏览器中执行，因此可以读取构建时并不存在的值：
 
 ```js
 // rsbuild.config.ts
@@ -158,8 +158,24 @@ defineConfig({
       domain: () => [
         // 可以是 http://localhost:3000，也可以是 https://cdn1.com。
         window.location.origin,
-        // 使用注入的变量，并提供兜底地址。
-        window.myAssetPath || 'https://cdn2.com/foo-path',
+        'https://cdn2.com/foo-path',
+        'https://cdn3.com',
+      ],
+    }),
+  ],
+});
+```
+
+也可以将自定义变量注入到 `window` 上，并在函数中使用：
+
+```js
+// rsbuild.config.ts
+defineConfig({
+  plugins: [
+    pluginAssetsRetry({
+      domain: () => [
+        window.myAssetPath,
+        'https://cdn2.com/foo-path',
         'https://cdn3.com',
       ],
     }),


### PR DESCRIPTION
## Summary

- align the full URL retry-domain snippet with the surrounding `defineConfig(...)` examples
- add a separate runtime example that reads an injected `window.myAssetPath` variable
- keep the English and Chinese README examples aligned

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm lint`
- `pnpm build`
- `pnpm test`
- `npm pack --dry-run`
