### PR TITLE
chore: release v2.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-assets-retry",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "An Rsbuild plugin to automatically resend requests when static assets fail to load.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

- bump `@rsbuild/plugin-assets-retry` from `2.0.1` to `2.0.2`
- prepare the release for runtime-resolved retry domains

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm lint`
- `pnpm build`
- `pnpm test`
- `npm pack --dry-run`
